### PR TITLE
Updated Readme for 2.8.10 (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Statamic Control Panel Translations ![Statamic 2.8.8](https://img.shields.io/badge/statamic-2.8.9-blue.svg?style=flat-square)
+# Statamic Control Panel Translations ![Statamic 2.8.10](https://img.shields.io/badge/statamic-2.8.10-blue.svg?style=flat-square)
 
 ## Installing a Translation
 
@@ -13,7 +13,7 @@ We're looking to the community to help with translation. Feel free to fork, edit
 ## Complete Translations
 
 - Dutch (nl) - Latest: 2.6.2
-- English (en) - Latest: 2.8.9
-- French (fr) - Latest: 2.8.9
+- English (en) - Latest: 2.8.10
+- French (fr) - Latest: 2.8.10
 - German (de) - Latest: 2.6.7
 - Russian (ru) - Latest: 2.8.8


### PR DESCRIPTION
* Updated Readme with Changes between versions

* Revert "Updated Readme with Changes between versions"

This reverts commit db720d22347bcbabce55b2af7704e901c1e065d9.

* 2.8.9 FRENCH and ENGLISH

The typo in cp.php ENGLISH 2.8.9 was corrected (language instead of
laguage)

* Updated Readme

* Updated Readme for 2.8.10